### PR TITLE
Tweaked JPA and Mongo Repositories for User Service

### DIFF
--- a/src/buildingblocks/src/main/java/buildingblocks/contracts/user/UserCreated.java
+++ b/src/buildingblocks/src/main/java/buildingblocks/contracts/user/UserCreated.java
@@ -1,0 +1,8 @@
+package buildingblocks.contracts.user;
+
+import buildingblocks.core.event.IntegrationEvent;
+
+import java.util.UUID;
+
+public record UserCreated(UUID Id) implements IntegrationEvent {
+}

--- a/src/services/user/src/main/java/com/distributedx/user/data/jpa/entities/UserEntity.java
+++ b/src/services/user/src/main/java/com/distributedx/user/data/jpa/entities/UserEntity.java
@@ -26,29 +26,29 @@ public class UserEntity extends BaseEntity<UUID> {
     @Embedded
     private UserName userName;
     @Embedded
+    private FullName fullName;
+    @Embedded
     private Email email;
     @Embedded
     private Password password;
-    @Embedded
-    @Column(name = "fullname")
-    private FullName fullName;
 
 
 
-    public UserEntity(UUID id, UserName userName, Email email, Password password, FullName fullName) {
+
+    public UserEntity(UUID id, UserName userName, FullName fullName, Email email, Password password) {
         this.id = id;
         this.userName = userName;
+        this.fullName = fullName;
         this.email = email;
         this.password = password;
-        this.fullName = fullName;
     }
 
-    public UserEntity(UUID id, UserName userName, Email email, Password password, FullName fullName, LocalDateTime createdAt, Long createdBy, LocalDateTime lastModified, Long lastModifiedBy, Long version, boolean isDeleted) {
+    public UserEntity(UUID id, UserName userName, FullName fullName, Email email, Password password, LocalDateTime createdAt, Long createdBy, LocalDateTime lastModified, Long lastModifiedBy, Long version, boolean isDeleted) {
         this.id = id;
         this.userName = userName;
+        this.fullName = fullName;
         this.email = email;
         this.password = password;
-        this.fullName = fullName;
         this.createdAt = createdAt;
         this.createdBy = createdBy;
         this.lastModified = lastModified;

--- a/src/services/user/src/main/java/com/distributedx/user/data/jpa/repositories/UserRepository.java
+++ b/src/services/user/src/main/java/com/distributedx/user/data/jpa/repositories/UserRepository.java
@@ -1,6 +1,7 @@
 package com.distributedx.user.data.jpa.repositories;
 
 import com.distributedx.user.data.jpa.entities.UserEntity;
+import com.distributedx.user.users.valueobjects.Email;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,5 @@ import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, UUID> {
-    //PassengerEntity findPassengerByPassportNumberAndIsDeletedFalse(PassportNumber passportNumber);
+    UserEntity findUserByEmailAndIsDeletedFalse(Email email);
 }

--- a/src/services/user/src/main/java/com/distributedx/user/data/mongo/documents/UserDocument.java
+++ b/src/services/user/src/main/java/com/distributedx/user/data/mongo/documents/UserDocument.java
@@ -1,0 +1,36 @@
+package com.distributedx.user.data.mongo.documents;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.UUID;
+
+
+@Document(collection = "users")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class UserDocument {
+    @Id
+    private ObjectId id;
+    private UUID userId;
+    private String userName;
+    private String fullName;
+    private String email;
+    private String password;
+    private boolean isDeleted;
+
+    public UserDocument(UUID userId, String userName, String fullName, String email, String password, boolean isDeleted) {
+        this.userId = userId;
+        this.userName = userName;
+        this.fullName = fullName;
+        this.email = email;
+        this.password = password;
+        this.isDeleted = isDeleted;
+    }
+}
+

--- a/src/services/user/src/main/java/com/distributedx/user/data/mongo/repositories/UserReadRepository.java
+++ b/src/services/user/src/main/java/com/distributedx/user/data/mongo/repositories/UserReadRepository.java
@@ -1,0 +1,12 @@
+package com.distributedx.user.data.mongo.repositories;
+
+import com.distributedx.user.data.mongo.documents.UserDocument;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.UUID;
+
+public interface UserReadRepository extends MongoRepository<UserDocument, ObjectId> {
+    UserDocument findUserByUserIdAndIsDeletedFalse(UUID userId);
+}
+

--- a/src/services/user/src/main/java/com/distributedx/user/users/dtos/UserDto.java
+++ b/src/services/user/src/main/java/com/distributedx/user/users/dtos/UserDto.java
@@ -1,17 +1,10 @@
 package com.distributedx.user.users.dtos;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record UserDto(
         UUID id,
-        String username,
-        String email,
+        String userName,
         String fullName,
-        String profilePictureUrl,
-        String bio,
-        LocalDateTime memberSince,
-        int followerCount,
-        int followingCount,
-        int postCount
+        String email
 ) { }

--- a/src/services/user/src/main/java/com/distributedx/user/users/features/createuser/UserCreatedDomainEvent.java
+++ b/src/services/user/src/main/java/com/distributedx/user/users/features/createuser/UserCreatedDomainEvent.java
@@ -1,0 +1,14 @@
+package com.distributedx.user.users.features.createuser;
+
+import buildingblocks.core.event.DomainEvent;
+
+import java.util.UUID;
+
+public record UserCreatedDomainEvent(
+        UUID id,
+        String userName,
+        String fullName,
+        String email,
+        String password,
+        boolean isDeleted) implements DomainEvent {
+}

--- a/src/services/user/src/main/java/com/distributedx/user/users/models/User.java
+++ b/src/services/user/src/main/java/com/distributedx/user/users/models/User.java
@@ -1,0 +1,57 @@
+package com.distributedx.user.users.models;
+
+import buildingblocks.core.model.AggregateRoot;
+import com.distributedx.user.users.valueobjects.*;
+import com.distributedx.user.users.features.createuser.UserCreatedDomainEvent;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter(AccessLevel.PRIVATE)
+public class User extends AggregateRoot<UserId> {
+    UserName userName;
+    FullName fullName;
+    Email email;
+    Password password;
+
+    public User(UserId userId, UserName userName, FullName fullName, Email email, Password password, LocalDateTime createdAt, Long createdBy, LocalDateTime lastModified, Long lastModifiedBy, Long version, boolean isDeleted) {
+       this.id = userId;
+       this.userName = userName;
+       this.fullName = fullName;
+       this.email = email;
+       this.password = password;
+       this.createdAt = createdAt;
+       this.createdBy = createdBy;
+       this.lastModified = lastModified;
+       this.lastModifiedBy = lastModifiedBy;
+       this.version = version;
+       this.isDeleted = isDeleted;
+    }
+
+    public User(UserId userId, UserName userName, FullName fullName, Email email, Password password) {
+        this.id = userId;
+        this.userName = userName;
+        this.fullName = fullName;
+        this.email = email;
+        this.password = password;
+    }
+
+    public static User create(UserId userId, UserName userName, FullName fullName, Email email, Password password) {
+        var user = new User(userId, userName, fullName, email, password);
+
+        user.addDomainEvent(new UserCreatedDomainEvent(
+                user.id.getUserId(),
+                user.userName.getUserName(),
+                user.fullName.getFullName(),
+                user.email.getEmail(),
+                user.password.getPassword(),
+                false
+        ));
+
+        return user;
+    }
+}

--- a/src/services/user/src/main/java/com/distributedx/user/users/valueobjects/UserId.java
+++ b/src/services/user/src/main/java/com/distributedx/user/users/valueobjects/UserId.java
@@ -1,0 +1,24 @@
+package com.distributedx.user.users.valueobjects;
+
+import buildingblocks.utils.validation.ValidationUtils;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor // Required by JPA
+@Getter
+public class UserId {
+    private UUID userId;
+
+    public UserId(UUID value) {
+        ValidationUtils.notBeNullOrEmpty(value);
+
+        this.userId = value;
+    }
+}


### PR DESCRIPTION
Implements core persistence layers for the User service including:

- Write-side repository (JPA)

- Read-side repository (MongoDB)

- Unified ID value object

- DTO and document representations